### PR TITLE
Asset Manifest Bug Fix

### DIFF
--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -296,7 +296,6 @@ class AssetLoader {
 			: $_dependencies;
 
 		if ( $this->use_production ) {
-			$register_url = $this->build_entry_url( $_base, $this->_configuration->style_path(), $_entry, 'css' );
 			wp_register_style(
 				$handle,
 				$this->build_entry_url( $_base, $this->_configuration->style_path(), $_entry, 'css' ),

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -118,7 +118,7 @@ class AssetLoader {
 	}
 
 	protected function asset_manifest() {
-		$base        = $this->use_production ? $this->_base_url : $this->_development_url_base;
+		$base        = $this->use_production ? $this->_configuration->production_file_path() : $this->_development_url_base;
 		$filename    = $base . $this->_configuration->asset_manifest_path();
 		$manifest    = null;
 		$use_context = $this->starts_with( $filename, 'http' );

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -125,7 +125,10 @@ class AssetLoader {
 
 		if ( file_exists( $filename ) || $use_context ) {
 			$context_arguments = [
-				'http' => [ 'ignore_errors' => true ]
+				'http' => [
+					'ignore_errors' => true,
+					'timeout'       => 15,
+				]
 			];
 
 			if ( $this->starts_with( $filename, 'https' ) ) {

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -123,6 +123,10 @@ class AssetLoader {
 		$manifest    = null;
 		$use_context = $this->starts_with( $filename, 'http' );
 
+		if ( ! $use_context ) {
+			$filename = realpath($_SERVER['DOCUMENT_ROOT']) . $filename;
+		}
+	
 		if ( file_exists( $filename ) || $use_context ) {
 			$context_arguments = [
 				'http' => [ 'ignore_errors' => true ]
@@ -292,6 +296,7 @@ class AssetLoader {
 			: $_dependencies;
 
 		if ( $this->use_production ) {
+			$register_url = $this->build_entry_url( $_base, $this->_configuration->style_path(), $_entry, 'css' );
 			wp_register_style(
 				$handle,
 				$this->build_entry_url( $_base, $this->_configuration->style_path(), $_entry, 'css' ),

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -123,10 +123,6 @@ class AssetLoader {
 		$manifest    = null;
 		$use_context = $this->starts_with( $filename, 'http' );
 
-		if ( ! $use_context ) {
-			$filename = realpath($_SERVER['DOCUMENT_ROOT']) . $filename;
-		}
-	
 		if ( file_exists( $filename ) || $use_context ) {
 			$context_arguments = [
 				'http' => [ 'ignore_errors' => true ]

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -124,6 +124,7 @@ class AssetLoader {
 		$use_context = $this->starts_with( $filename, 'http' );
 
 		if ( file_exists( $filename ) || $use_context ) {
+			// Set timeout to 15 seconds for HTTP requests
 			$context_arguments = [
 				'http' => [
 					'ignore_errors' => true,

--- a/src/Model/LoaderConfiguration.php
+++ b/src/Model/LoaderConfiguration.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Webpack Asset Loader Configuration
  */
@@ -30,6 +30,13 @@ class LoaderConfiguration {
     protected array $_production_domains;
 
     /**
+	 * Root file path to the files in production, to find the asset manifest
+	 *
+	 * @var string
+	 */
+	protected string $_production_file_path;
+
+    /**
 	 * @var string
 	 */
 	protected string $_script_path;
@@ -59,6 +66,7 @@ class LoaderConfiguration {
 	 * @param ?string $_script_path
 	 * @param ?string $_style_path
 	 * @param ?string $_static_path
+	 * @param ?string $_production_file_path
 	 */
 	public function __construct(
         ?string $_version = null,
@@ -67,15 +75,17 @@ class LoaderConfiguration {
 		?string $_handle_prefix = null,
 		?string $_script_path = null,
 		?string $_style_path = null,
-		?string $_static_path = null
+		?string $_static_path = null,
+		?string $_production_file_path = null
 	) {
-        $this->_version             = $this->check_string( $_version, null );
-		$this->_asset_manifest_path = $this->check_string( $_asset_manifest_path, '' );
-		$this->_handle_prefix       = $this->check_string( $_handle_prefix, self::DEFAULT_PREFIX );
-		$this->_script_path         = $this->check_string( $_script_path, self::DEFAULT_SCRIPT_PATH );
-		$this->_static_path         = $this->check_string( $_static_path, self::DEFAULT_STATIC_PATH );
-		$this->_style_path          = $this->check_string( $_style_path, self::DEFAULT_STYLE_PATH );
-        $this->_production_domains  = is_array( $_production_domains ) ? $_production_domains : [];
+        $this->_version              = $this->check_string( $_version, null );
+		$this->_asset_manifest_path  = $this->check_string( $_asset_manifest_path, '' );
+		$this->_handle_prefix        = $this->check_string( $_handle_prefix, self::DEFAULT_PREFIX );
+		$this->_script_path          = $this->check_string( $_script_path, self::DEFAULT_SCRIPT_PATH );
+		$this->_static_path          = $this->check_string( $_static_path, self::DEFAULT_STATIC_PATH );
+		$this->_style_path           = $this->check_string( $_style_path, self::DEFAULT_STYLE_PATH );
+        $this->_production_domains   = is_array( $_production_domains ) ? $_production_domains : [];
+		$this->_production_file_path = $this->check_string( $_production_file_path, '' );
 	}
 
     /**
@@ -114,6 +124,13 @@ class LoaderConfiguration {
     /**
      * Url path fragment before scripts
      */
+	public function production_file_path() : string {
+        return $this->_production_file_path;
+    }
+
+    /**
+     * Url path fragment before scripts
+     */
 	public function script_path() : string {
         return $this->_script_path;
     }
@@ -131,7 +148,7 @@ class LoaderConfiguration {
 	public function style_path() : string {
         return $this->_style_path;
     }
-	
+
     /**
      * Asset version passed to enqueue calls
      */

--- a/src/Registry/WordPress.php
+++ b/src/Registry/WordPress.php
@@ -53,7 +53,7 @@ class WordPress {
         ?string $_development_url = null
     ) {
         $this->_configuration = $_configuration;
-        $this->_production_url = !empty( $$_production_url ) ? $_production_url : get_stylesheet_directory_uri();
+        $this->_production_url = !empty( $$_production_url ) ? $_production_url : get_stylesheet_directory(); // this is where we want to change things. 
         $this->_development_url = !empty( $_development_url ) 
             ? $_development_url
             : ( defined( 'KANOPI_DEVELOPMENT_ASSET_URL' ) ? KANOPI_DEVELOPMENT_ASSET_URL : '' );
@@ -124,7 +124,7 @@ class WordPress {
     protected function register_loader(): void {
         try {
             $this->_loader = new AssetLoader(
-                $this->_production_url,
+                $this->_production_url, // prod URL or path
                 $this->_development_url,
                 $this->_configuration
             );

--- a/src/Registry/WordPress.php
+++ b/src/Registry/WordPress.php
@@ -53,7 +53,7 @@ class WordPress {
         ?string $_development_url = null
     ) {
         $this->_configuration = $_configuration;
-        $this->_production_url = !empty( $$_production_url ) ? $_production_url : get_stylesheet_directory(); // this is where we want to change things. 
+        $this->_production_url = !empty( $_production_url ) ? $_production_url : str_replace( ABSPATH, '/', get_stylesheet_directory() );
         $this->_development_url = !empty( $_development_url ) 
             ? $_development_url
             : ( defined( 'KANOPI_DEVELOPMENT_ASSET_URL' ) ? KANOPI_DEVELOPMENT_ASSET_URL : '' );
@@ -124,7 +124,7 @@ class WordPress {
     protected function register_loader(): void {
         try {
             $this->_loader = new AssetLoader(
-                $this->_production_url, // prod URL or path
+                $this->_production_url,
                 $this->_development_url,
                 $this->_configuration
             );


### PR DESCRIPTION
## Description
> As a developer, I need my Asset Loader to be able to load assets in Production by either filepath or HTTP/HTTPS. I also need my default to be by filepath.

## Affected URL
Local Only


## Related Tickets
https://kanopi.teamwork.com/tasks/29110559

## Steps to Validate
1. Via composer, load `kanopi-pack-aset-loader` using the `feature/tw29110559/asset-manifest` branch, rather than `main`
2. Run `fin production` on your project, and comment out `KANOPI_DEVELOPMENT_ASSET_URL` in your `wp-config.php`
3. Test to make sure your assets are loading
4. In `functions.php`, pass in the stylesheet directory URI for your project to the Loader Configuration. 
5. Verify that assets still load
6. Verify that `fin development` still works, by uncommenting the KANOPI_DEVELOPMENT_ASSET_URL environment variable in `wp-config.php`

## Notes

1. When passing in a URL, we must pass in the path to the stylesheet directory. This should be noted in documentation.
2. If passing in a filepath, such as `get_stylesheet_directory()`, we will need to run a `str_replace` to remove the absolute path, so that `wp_enqueue_scripts/wp_enqueue_styles` can read the file properly. Again, this should be documented.