### PR TITLE
WordPress Block Script and Style Registration Only

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -10,6 +10,13 @@
 	<arg name="basepath" value="./"/>
 	<arg name="extensions" value="php"/>
 	<arg name="parallel" value="8"/>
+	<arg value="ps"/>
+
+	<!--
+	Suppress errors thrown by WordPress Coding Standards when run on PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED"/>
 
 	<file>.</file>
 	<include-pattern>*/src/**/*</include-pattern>

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,12 @@ php80:
 php81:
 	$(MAKE) phptest VERSION=8.1
 
+.PHONY: php82
+
+php82:
+	$(MAKE) phptest VERSION=8.2
+
 .PHONY: test
 
 test:
-	$(MAKE) -j 3 php74 php80 php81
+	$(MAKE) -j 4 php74 php80 php81 php82

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -574,7 +574,7 @@ class AssetLoader {
 		}
 		else {
 			// Dependencies deliberately disabled in Dev Mode as scripts cannot depend on styles
-			wp_register_script(
+			wp_enqueue_script(
 				$handle,
 				$this->build_entry_url( $this->_development_url_base, $this->_configuration->script_path(), $entry, 'js' ),
 				[],

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -365,8 +365,8 @@ class AssetLoader {
 	/**
 	 * Register Webpack delivered application (contains both scripts and styles in Production, scripts in development)
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_applications( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_script( $_entry_point, $_dependencies );
@@ -379,9 +379,9 @@ class AssetLoader {
 	/**
 	 * Set/overwrite an asset with dependencies by entry point
 	 *
-	 * @param array  $_target
-	 * @param string $_entry
-	 * @param array  $_dependencies
+	 * @param array  $_target       Set of assets to add the registration
+	 * @param string $_entry        Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	protected function register_dependencies( array &$_target, string $_entry, array $_dependencies ) {
 		$entry = strtolower( trim( $_entry ) );
@@ -393,8 +393,8 @@ class AssetLoader {
 	/**
 	 * Register any webpack-dev-server runtime dependencies
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_runtime_script( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->runtime_scripts, $_entry_point, $_dependencies );
@@ -403,8 +403,8 @@ class AssetLoader {
 	/**
 	 * Register Webpack delivered application scripts
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_script( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->scripts, $_entry_point, $_dependencies );
@@ -413,8 +413,8 @@ class AssetLoader {
 	/**
 	 * Register Webpack delivered application stylesheets
 	 *
-	 * @param string  $_entry_point  Name of the entry point in the Webpack Configuration
-	 * @param array   $_dependencies Dependencies required before enqueuing this stylesheet
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_style( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->styles, $_entry_point, $_dependencies );
@@ -424,8 +424,8 @@ class AssetLoader {
 	 * Register Webpack delivered vendor applications (mix of scripts and styles in production, just scripts in
 	 * development)
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_vendor_application( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_vendor_script( $_entry_point, $_dependencies );
@@ -438,8 +438,8 @@ class AssetLoader {
 	/**
 	 * Register Webpack delivered vendor scripts
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_vendor_script( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->vendor_scripts, $_entry_point, $_dependencies );
@@ -448,8 +448,8 @@ class AssetLoader {
 	/**
 	 * Register Webpack delivered vendor stylesheets
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_vendor_styles( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->vendor_styles, $_entry_point, $_dependencies );
@@ -458,9 +458,15 @@ class AssetLoader {
 	/**
 	 * Use to Register a stylesheet handle for an entrypoint, does not add the script to queue for enqueue_assets()
 	 *
-	 * @param string  $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param string $_entry_point      Name of the entry point in the Webpack Configuration
+	 * @param array  $_dependencies     Dependencies required before enqueuing this stylesheet
+	 * @param array  $_dev_dependencies Dependencies required before enqueuing this stylesheet in Dev
 	 */
-	public function style_handle_registration( string $_entry_point ): void {
+	public function style_handle_registration( 
+		string $_entry_point,
+		array $_dependencies = [],
+		array $_dev_dependencies = []
+	): void {
 		$entry  = strtolower( trim( $_entry_point ) );
 		$handle = $this->prefixed_entry_name( $entry );
 		
@@ -468,7 +474,7 @@ class AssetLoader {
 			wp_register_style(
 				$handle,
 				$this->build_entry_url( $this->_base_url, $this->_configuration->style_path(), $entry, 'css' ),
-				[],
+				$_dependencies,
 				$this->_configuration->version() );
 		}
 		else {
@@ -476,7 +482,7 @@ class AssetLoader {
 			wp_register_script(
 				$handle,
 				$this->build_entry_url( $this->_development_url_base, $this->_configuration->script_path(), $entry, 'js' ),
-				[],
+				$_dev_dependencies,
 				$this->_configuration->version(),
 				$this->_configuration->development_styles_in_head()
 			);

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -413,8 +413,8 @@ class AssetLoader {
 	/**
 	 * Register Webpack delivered application stylesheets
 	 *
-	 * @param string $_entry_point
-	 * @param array  $_dependencies
+	 * @param string  $_entry_point  Name of the entry point in the Webpack Configuration
+	 * @param array   $_dependencies Dependencies required before enqueuing this stylesheet
 	 */
 	public function register_style( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->styles, $_entry_point, $_dependencies );
@@ -453,6 +453,34 @@ class AssetLoader {
 	 */
 	public function register_vendor_styles( string $_entry_point, array $_dependencies = [] ) {
 		$this->register_dependencies( $this->vendor_styles, $_entry_point, $_dependencies );
+	}
+
+	/**
+	 * Use to Register a stylesheet handle for an entrypoint, does not add the script to queue for enqueue_assets()
+	 *
+	 * @param string  $_entry_point  Name of the entry point in the Webpack Configuration
+	 */
+	public function style_handle_registration( string $_entry_point ): void {
+		$entry  = strtolower( trim( $_entry_point ) );
+		$handle = $this->prefixed_entry_name( $entry );
+		
+		if ( $this->use_production ) {
+			wp_register_style(
+				$handle,
+				$this->build_entry_url( $this->_base_url, $this->_configuration->style_path(), $entry, 'css' ),
+				[],
+				$this->_configuration->version() );
+		}
+		else {
+			// Dependencies deliberately disabled in Dev Mode as scripts cannot depend on styles
+			wp_register_script(
+				$handle,
+				$this->build_entry_url( $this->_development_url_base, $this->_configuration->script_path(), $entry, 'js' ),
+				[],
+				$this->_configuration->version(),
+				$this->_configuration->development_styles_in_head()
+			);
+		}
 	}
 
 	/**

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -524,12 +524,7 @@ class AssetLoader {
 			);
 		}
 		else {
-			wp_enqueue_script(
-				$handle,
-				$this->build_entry_url( $this->_development_url_base, $this->_configuration->script_path(), $entry, 'js' ),
-				[],
-				$this->_configuration->version()
-			);
+			$this->register_script( $entry );
 		}
 	}
 	
@@ -574,13 +569,7 @@ class AssetLoader {
 		}
 		else {
 			// Dependencies deliberately disabled in Dev Mode as scripts cannot depend on styles
-			wp_enqueue_script(
-				$handle,
-				$this->build_entry_url( $this->_development_url_base, $this->_configuration->script_path(), $entry, 'js' ),
-				[],
-				$this->_configuration->version(),
-				$this->_configuration->development_styles_in_head()
-			);
+			$this->register_script( $entry );
 		}
 	}
 	

--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -509,14 +509,25 @@ class AssetLoader {
 		if ( $this->use_production ) {
 			wp_register_style(
 				$handle,
-				$this->build_entry_path(
-					$this->_configuration->production_file_path(),
+				$this->build_entry_url(
+					$this->_base_url,
 					$this->_configuration->style_path(),
 					$entry,
 					'css'
 				),
 				$_dependencies,
 				$this->_configuration->version()
+			);
+
+			wp_style_add_data(
+				$handle,
+				'path',
+				$this->build_entry_path(
+					$this->_configuration->production_file_path(),
+					$this->_configuration->style_path(),
+					$entry,
+					'css'
+				)
 			);
 		}
 		else {

--- a/src/Model/LoaderConfiguration.php
+++ b/src/Model/LoaderConfiguration.php
@@ -63,15 +63,15 @@ class LoaderConfiguration {
 	/**
 	 * LoaderConfiguration constructor.
 	 *
-	 * @param ?string $_version
-	 * @param ?array  $_production_domains
-	 * @param ?string $_asset_manifest_path
-	 * @param ?string $_handle_prefix
-	 * @param ?string $_script_path
-	 * @param ?string $_style_path
-	 * @param ?string $_static_path
-	 * @param ?string $_production_file_path
-	 * @param ?bool   $_development_styles_in_head
+	 * @param ?string $_version                     Version to assign stylesheet URL
+	 * @param ?array  $_production_domains          Guaranteed Production domains
+	 * @param ?string $_asset_manifest_path         Relative path to the Asset Manifest file
+	 * @param ?string $_handle_prefix               Prefix before the entry point handle
+	 * @param ?string $_script_path                 Relative path to scripts
+	 * @param ?string $_style_path                  Relative path to styles
+	 * @param ?string $_static_path                 Relative path to static files
+	 * @param ?string $_production_file_path        Production file path (for Asset Manifest and WP Blocks)
+	 * @param ?bool   $_development_styles_in_head  Whether to include development styles in the head tag
 	 */
 	public function __construct(
 		?string $_version = null,

--- a/src/Registry/WordPress.php
+++ b/src/Registry/WordPress.php
@@ -57,8 +57,8 @@ class WordPress {
      * Build an asset loader instance with the provided configuration
      *
      * @param LoaderConfiguration   $_configuration     Configuration for the AssetLoader instance
-     * @param ?string               $_production_url    (Optional) Production URL base path, defaults to theme directory
-     * @param ?string               $_development_url   (Optional) Development URL base path, defaults to KANOPI_DEVELOPMENT_ASSET_URL or empty
+     * @param ?string               $_production_url    (Optional) URL path, default of theme directory
+     * @param ?string               $_development_url   (Optional) URL path, default of KANOPI_DEVELOPMENT_ASSET_URL
      */
 
     public function __construct(
@@ -66,11 +66,10 @@ class WordPress {
         ?string $_production_url = null,
         ?string $_development_url = null
     ) {
-        $this->_configuration = $_configuration;
-        $this->_production_url = !empty( $_production_url ) ? $_production_url : get_stylesheet_directory_uri();
-        $this->_development_url = !empty( $_development_url )
-            ? $_development_url
-            : ( defined( 'KANOPI_DEVELOPMENT_ASSET_URL' ) ? KANOPI_DEVELOPMENT_ASSET_URL : '' );
+        $defaultDevelopmentUrl  = defined( 'KANOPI_DEVELOPMENT_ASSET_URL' ) ? KANOPI_DEVELOPMENT_ASSET_URL : '';
+        $this->_configuration   = $_configuration;
+        $this->_production_url  = !empty( $_production_url ) ? $_production_url : get_stylesheet_directory_uri();
+        $this->_development_url = !empty( $_development_url ) ? $_development_url : $defaultDevelopmentUrl;
 
 		// Bugfix to workaround limitations with current loader to ensure the manifest is loaded via file path in production
 		if ( empty( $this->_configuration->production_file_path() ) ) {
@@ -97,7 +96,7 @@ class WordPress {
      * @param LoaderConfiguration   $_configuration     Configuration for the AssetLoader instance
      * @param string                $_instance_name     (Optional) Registered instance handle/name
      * @param ?string               $_production_url    (Optional) Production URL base path, defaults to theme directory
-     * @param ?string               $_development_url   (Optional) Development URL base path, defaults to KANOPI_DEVELOPMENT_ASSET_URL or empty
+     * @param ?string               $_development_url   (Optional) URL path, default of KANOPI_DEVELOPMENT_ASSET_URL
      */
     public static function register(
         LoaderConfiguration $_configuration,
@@ -106,7 +105,8 @@ class WordPress {
         ?string $_development_url = null
     ) : WordPress {
         if ( empty( self::$_instances ) || empty( self::$_instances[ $_instance_name ] ) ) {
-            self::$_instances[ $_instance_name ] = new WordPress( $_configuration, $_production_url, $_development_url );
+            self::$_instances[ $_instance_name ] = 
+                new WordPress( $_configuration, $_production_url, $_development_url );
         }
 
         return self::$_instances[ $_instance_name ];


### PR DESCRIPTION
## Description
> As a developer, I want to support the ability for WordPress to only add Black CSS and JS for pages where the associated block is actually used.

The adds functions `register_script_handle` and `register_style_handle` which allow dynamic inclusion in Production mode. Due to limitations in Dev mode, things always run as scripts, this method does not work without further effort. Since this is primarily a performance optimization for Production, this is an acceptable trade-off for now.


## Steps to Validate
1. Update to this feature on a Kanopi Pack based WordPress project using Gutenberg blocks.
2. Add a new Test block along with new entry points for its CSS and JS
3. Use the `register_script_handle` and `register_style_handle` functions to add the entry points where other scripts and styles are registered
4. Update the block.json to use the prefixed handles for the CSS and JS entries
5. Add the block to a page
6. Check in Dev mode and ensure styles and scripts work.
7. Compile and switch to Production mode.
8. Ensure the CSS and JS only load on pages where the block is used.
