### PR TITLE
Register Only Script Dependency Fix

### DIFF
--- a/src/AssetLoader.php
+++ b/src/AssetLoader.php
@@ -524,14 +524,14 @@ class AssetLoader {
 			);
 		}
 		else {
-			$this->register_script( $entry );
+			$this->register_script( $entry, $_dependencies );
 		}
 	}
 	
 	/**
 	 * Use to Register a stylesheet handle for an entrypoint, does not add the style to queue for enqueue_assets()
 	 * - Enables dynamic inclusions and inlining in Production mode for block styles
-	 * - Dev mode always registers and enqueues
+	 * - Dev mode always registers and enqueues, though as scripts, so it will ignore Dependencies due to type mismatch
 	 *
 	 * @param string $_entry_point  Name of the entry point in the Webpack Configuration
 	 * @param array  $_dependencies Dependencies required before enqueuing this stylesheet


### PR DESCRIPTION
## Description

Pass script dependencies through in Development mode for register only scripts (register_script_handle)

## Steps to Validate
1. See associated Issue #13 
2. From a WordPress project using this library, switch to this hotfix branch
3. Create a Test Block (or use an existing block) to recreate the Issue described
4. Verify the Block and it's dependencies load as expected in both Dev and Prod modes.